### PR TITLE
Fix incorrect escape over international characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 /// ```
 pub fn escape(input: &str) -> String {
     lazy_static! {
-        static ref ESCAPE_PATTERN: Regex = Regex::new(r"([^A-Za-z0-9_\-.,:/@\n])").unwrap();
+        static ref ESCAPE_PATTERN: Regex = Regex::new(r"([^\p{L}0-9_\-.,:/@\n])").unwrap();
         static ref LINE_FEED: Regex = Regex::new(r"\n").unwrap();
     }
 
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn escape_multibyte() {
-        assert_eq!(escape("あい"), "\\あ\\い");
+        assert_eq!(escape("あい"), "あい");
     }
 
     #[test]


### PR DESCRIPTION
International characters should not be escaped in the shell. Check out the screenshot below:
![image](https://user-images.githubusercontent.com/30107576/162510749-336dc5bb-2d2f-4cbc-82fe-4b3cd2547e28.png)

So instead of matching only english alphabets in the escape pattern, we match for letters instead (which includes both alphabets and international letters). For more information on `\p{L}` syntax, check out regex documentation here: https://www.regular-expressions.info/unicode.html